### PR TITLE
Added functionality yearByYear for player_stat_data

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1091,6 +1091,7 @@ def player_stat_data(personId, group="[hitting,pitching,fielding]", type="season
             stat_group = {
                 "type": s["type"]["displayName"],
                 "group": s["group"]["displayName"],
+                "season": s["splits"][i].get("season"),
                 "stats": s["splits"][i]["stat"],
             }
             stat_groups.append(stat_group)


### PR DESCRIPTION
made changes to statsapi.player_stat_data()
By setting the type field to yearByYear it retrieves all stats correctly without identifying which season the stats refer to.
I added a season field to each stat_group so each stat_group can be identified by year.
To Do: Add yearByYear parameter to the wiki