### PR TITLE
v0.1.8

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -36,7 +36,7 @@ ENDPOINTS = endpoints.ENDPOINTS
 
 logger = logging.getLogger("statsapi")
 
-# Trying to support Python 2.7:
+# Python 2 Support Warning
 if sys.version_info.major < 3:
     logger.warning(
         "WARNING: Support for Python 2 will be discontinued on or after "

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -36,6 +36,14 @@ ENDPOINTS = endpoints.ENDPOINTS
 
 logger = logging.getLogger("statsapi")
 
+# Trying to support Python 2.7:
+if sys.version_info.major < 3:
+    logger.warning(
+        "WARNING: Support for Python 2 will be discontinued on or after "
+        "January 1, 2021. The MLB-StatsAPI module may continue to function, but "
+        "issues not impacting Python 3 will be closed and support will not be provided."
+    )
+
 
 def schedule(
     date=None,

--- a/statsapi/endpoints.py
+++ b/statsapi/endpoints.py
@@ -1097,6 +1097,8 @@ ENDPOINTS = {
             "order",
             "sortStat",
             "fields",
+            "startDate",
+            "endDate",
         ],
         "required_params": [["season", "group", "stats"]],
         "note": "Use meta('statGroups') to look up valid values for group, and meta('statTypes') for valid values for stats.",

--- a/statsapi/version.py
+++ b/statsapi/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "0.1.7"
+VERSION = "0.1.8"


### PR DESCRIPTION
FIX: Add missing startDate and endDate params to teams_stats endpoint config
ENH: Include venue id and name in the schedule return data
NEW: Support warning for Python 2 - Support will be dropped on/after Jan 1, 2021