### PR TITLE
Raise HTTPError when HTTP requests fail

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-mock
+responses

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1641,7 +1641,7 @@ def get(endpoint, params, force=False):
     # Make the request
     r = requests.get(url)
     if r.status_code not in [200, 201]:
-        raise ValueError("Request failed. Status Code: " + str(r.status_code) + ".")
+        r.raise_for_status()
     else:
         return r.json()
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,11 +1,13 @@
 import statsapi
 import pytest
+import requests.exceptions
+import responses
 
 
 def fake_dict():
     return {
         "foo": {
-            "url": "www.foo.com",
+            "url": "http://www.foo.com",
             "path_params": {
                 "ver": {
                     "type": "str",
@@ -45,21 +47,23 @@ def test_get_calls_correct_url(mocker):
     except ValueError:
         pass
 
-    mock_req.get.assert_called_with("www.foo.com?bar=baz")
+    mock_req.get.assert_called_with("http://www.foo.com?bar=baz")
 
 
-def test_get_raises_errors(mocker):
+@responses.activate
+def test_get_server_error(mocker):
+    # mock the ENDPOINTS dictionary
+    mocker.patch.dict("statsapi.ENDPOINTS", fake_dict(), clear=True)
+    responses.add(responses.GET, 'http://www.foo.com?bar=baz', status=500)
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        statsapi.get("foo", {"bar": "baz"})
+
+def test_get_invalid_endpoint(mocker):
     # mock the ENDPOINTS dictionary
     mocker.patch.dict("statsapi.ENDPOINTS", fake_dict(), clear=True)
     # mock the requests object
     mock_req = mocker.patch("statsapi.requests", autospec=True)
-    # mock the status code to always be 200
-    mock_req.get.return_value.status_code = 0
-
-    # bad status code
-    with pytest.raises(ValueError):
-        statsapi.get("foo", {"bar": "baz"})
-
     # invalid endpoint
     with pytest.raises(ValueError):
         statsapi.get("bar", {"foo": "baz"})

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -42,11 +42,7 @@ def test_get_calls_correct_url(mocker):
     # mock the requests object
     mock_req = mocker.patch("statsapi.requests", autospec=True)
 
-    try:
-        statsapi.get("foo", {"bar": "baz"})
-    except ValueError:
-        pass
-
+    statsapi.get("foo", {"bar": "baz"})
     mock_req.get.assert_called_with("http://www.foo.com?bar=baz")
 
 


### PR DESCRIPTION
When the `statsapi.get` method encounters a response code other than 200 or 201 it will raise a `requests.exceptions.HTTPError`. Previously it would raise a `ValueError`.

This should allow client code to more easily retry transient HTTP errors automatically.

This is an API change, so let me know if you'd like me to bump the version number too, or if you'd rather do that next time you release.

It also adds a test dependency on the [`responses`](https://github.com/getsentry/responses) library for setting up fake HTTP responses for `requests`. I think it more thorough exercises the code vs. mocking `requests` in this case and asserting that `raise_for_status` was called on the response. Let me know if you have any concerns about another test dependency though.

This is to resolve issue #46.