### PR TITLE
Use reverse index to find actual last game

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -876,7 +876,7 @@ def last_game(teamId):
             "hydrate": "previousSchedule",
             "fields": "teams,id,teamName,previousGameSchedule,dates,date,games,gamePk,season,gameDate,teams,away,home,team,name",
         },
-    )["teams"][0]["previousGameSchedule"]["dates"][-1]["games"][0]["gamePk"]
+    )["teams"][0]["previousGameSchedule"]["dates"][-2]["games"][0]["gamePk"]
 
 
 def next_game(teamId):

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -876,7 +876,7 @@ def last_game(teamId):
             "hydrate": "previousSchedule",
             "fields": "teams,id,teamName,previousGameSchedule,dates,date,games,gamePk,season,gameDate,teams,away,home,team,name",
         },
-    )["teams"][0]["previousGameSchedule"]["dates"][0]["games"][0]["gamePk"]
+    )["teams"][0]["previousGameSchedule"]["dates"][-1]["games"][0]["gamePk"]
 
 
 def next_game(teamId):


### PR DESCRIPTION
Not sure if it's a recent change but when calling the endpoint with the previous parameters, the [output](https://pastebin.com/0d5BQJ5H) contains five games which descends with time. See in example - 2021-06-13, NYY @ PHI 0-7 is the first index. Last index is 2021-06-18, the upcoming game OAK @ NYY (at time of writing). Second to last index is 2021-06-17, NYY @ TOR 8-4 which is the actual last game.