### PR TITLE
Add national broadcast data to schedule

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -77,7 +77,7 @@ def schedule(
     params.update(
         {
             "sportId": str(sportId),
-            "hydrate": "decisions,probablePitcher(note),linescore,broadcasts",
+            "hydrate": "decisions,probablePitcher(note),linescore,broadcasts,game(content(media(epg)))",
         }
     )
 
@@ -129,6 +129,8 @@ def schedule(
                         )
                     ),
                 }
+                if game["content"].get("media", {}).get("freeGame", False):
+                    game_info["national_broadcasts"].append("MLB.tv Free Game")
                 if game_info["status"] in ["Final", "Game Over"]:
                     if game.get("isTie"):
                         game_info.update({"winning_team": "Tie", "losing_Team": "Tie"})
@@ -1346,20 +1348,8 @@ def standings(
     for div in divisions.values():
         standings += div["div_name"] + "\n"
         if include_wildcard:
-            standings += (
-                "{:^4} {:<21} {:^3} {:^3} {:^4} {:^4} {:^7} {:^5} {:^4}\n".format(
-                    *[
-                        "Rank",
-                        "Team",
-                        "W",
-                        "L",
-                        "GB",
-                        "(E#)",
-                        "WC Rank",
-                        "WC GB",
-                        "(E#)",
-                    ]
-                )
+            standings += "{:^4} {:<21} {:^3} {:^3} {:^4} {:^4} {:^7} {:^5} {:^4}\n".format(
+                *["Rank", "Team", "W", "L", "GB", "(E#)", "WC Rank", "WC GB", "(E#)",]
             )
             for t in div["teams"]:
                 standings += "{div_rank:^4} {name:<21} {w:^3} {l:^3} {gb:^4} {elim_num:^4} {wc_rank:^7} {wc_gb:^5} {wc_elim_num:^4}\n".format(

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -77,7 +77,7 @@ def schedule(
     params.update(
         {
             "sportId": str(sportId),
-            "hydrate": "decisions,probablePitcher(note),linescore",
+            "hydrate": "decisions,probablePitcher(note),linescore,broadcasts",
         }
     )
 
@@ -121,6 +121,13 @@ def schedule(
                     "inning_state": game.get("linescore", {}).get("inningState", ""),
                     "venue_id": game.get("venue", {}).get("id"),
                     "venue_name": game.get("venue", {}).get("name"),
+                    "national_broadcasts": list(
+                        set(
+                            broadcast["name"]
+                            for broadcast in game.get("broadcasts", [])
+                            if broadcast.get("isNational", False)
+                        )
+                    ),
                 }
                 if game_info["status"] in ["Final", "Game Over"]:
                     if game.get("isTie"):


### PR DESCRIPTION
Closes #71. Adds a list with the broadcast names if they exist, otherwise it is empty. 

Example:

```python
In [1]: import statsapi

In [2]: statsapi.schedule(game_id=661713)
Out[2]: 
[{'game_id': 661713,
  'game_datetime': '2022-07-29T23:07:00Z',
  'game_date': '2022-07-29',
  'game_type': 'R',
  'status': 'Final',
  'away_name': 'Detroit Tigers',
  'home_name': 'Toronto Blue Jays',
  'away_id': 116,
  'home_id': 141,
  'doubleheader': 'N',
  'game_num': 1,
  'home_probable_pitcher': 'Alek Manoah',
  'away_probable_pitcher': 'Bryan Garcia',
  'home_pitcher_note': '',
  'away_pitcher_note': '',
  'away_score': 4,
  'home_score': 2,
  'current_inning': 9,
  'inning_state': 'Bottom',
  'venue_id': 14,
  'venue_name': 'Rogers Centre',
  'national_broadcasts': ['Apple TV+'],  #### NEW ####
  'winning_team': 'Detroit Tigers',
  'losing_team': 'Toronto Blue Jays',
  'winning_pitcher': 'Will Vest',
  'losing_pitcher': 'Alek Manoah',
  'save_pitcher': 'Gregory Soto',
  'summary': '2022-07-29 - Detroit Tigers (4) @ Toronto Blue Jays (2) (Final)'}]
```