### PR TITLE
Add series_status to schedule

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -77,7 +77,7 @@ def schedule(
     params.update(
         {
             "sportId": str(sportId),
-            "hydrate": "decisions,probablePitcher(note),linescore,broadcasts,game(content(media(epg)))",
+            "hydrate": "decisions,probablePitcher(note),linescore,broadcasts,game(content(media(epg))),seriesStatus",
         }
     )
 
@@ -128,6 +128,7 @@ def schedule(
                             if broadcast.get("isNational", False)
                         )
                     ),
+                    "series_status": game.get("seriesStatus", {}).get("result"),
                 }
                 if game["content"].get("media", {}).get("freeGame", False):
                     game_info["national_broadcasts"].append("MLB.tv Free Game")


### PR DESCRIPTION
This exposes the `seriesStatus(result)` field to the `schedule()` function. This is mainly useful during the postseason, but exists year-round.

Example:
```python
>>> import statsapi
>>> # game which has finished
>>> print(statsapi.schedule()[0]['series_status'])
HOU leads 2-0
>>> # game which is scheduled
>>> print(statsapi.schedule('2022-10-14')[1]['series_status']) 
Series tied 1-1
```