### PR TITLE
Check if highlights exist gracefully

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1038,15 +1038,12 @@ def game_highlight_data(gamePk):
             "fields": "dates,date,games,gamePk,content,highlights,items,headline,type,value,title,description,duration,playbacks,name,url",
         },
     )
-    if not len(
-        r["dates"][0]["games"][0]["content"]["highlights"]["highlights"]["items"]
-    ):
-        return ""
-
-    items = r["dates"][0]["games"][0]["content"]["highlights"]["highlights"]["items"]
+    gameHighlights = r["dates"][0]["games"][0]["content"]["highlights"]["highlights"]
+    if not gameHighlights or len(gameHighlights) == 0:
+        return []
 
     unorderedHighlights = {}
-    for v in (x for x in items if isinstance(x, dict) and x["type"] == "video"):
+    for v in (x for x in gameHighlights["items"] if isinstance(x, dict) and x["type"] == "video"):
         unorderedHighlights.update({v["date"]: v})
 
     sortedHighlights = []

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1039,7 +1039,7 @@ def game_highlight_data(gamePk):
         },
     )
     gameHighlights = r["dates"][0]["games"][0]["content"]["highlights"]["highlights"]
-    if not gameHighlights or len(gameHighlights) == 0:
+    if not gameHighlights or len(gameHighlights["items"]) == 0:
         return []
 
     unorderedHighlights = {}


### PR DESCRIPTION
Currently, the `highlights` object can be None, such as here:
```python
>>> r = get(
...         "schedule",
...         {
...             "sportId": 1,
...             "gamePk": gamePk,
...             "hydrate": "game(content(highlights(highlights)))",
...             "fields": "dates,date,games,gamePk,content,highlights,items,headline,type,value,title,description,duration,playbacks,name,url",
...         },
...     )
>>>
>>> r
{'dates': [{'date': '2023-02-25', 'games': [{'gamePk': 719386, 'content': {'highlights': {'highlights': None}}}]}]}
```

The change both checks for it gracefully rather than throwing a `TypeError: 'NoneType' object is not subscriptable` and returns an empty list rather than an empty string, to match the other return values