### PR TITLE
Fix KeyError : 'eliminationNumber' in standings_data

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1493,7 +1493,7 @@ def standings_data(
                 "wc_rank": x.get("wildCardRank", "-"),
                 "wc_gb": x.get("wildCardGamesBack", "-"),
                 "wc_elim_num": x.get("wildCardEliminationNumber", "-"),
-                "elim_num": x["eliminationNumber"],
+                "elim_num": x.get("eliminationNumber", "-"),
                 "team_id": x["team"]["id"],
                 "league_rank": x["leagueRank"],
                 "sport_rank": x["sportRank"],


### PR DESCRIPTION
statsapi.standings(leagueId="103,104", season=2023, standingsTypes='springTraining') can now return data instead of throwing KeyError: 'eliminationNumber'