### PR TITLE
Fix KeyError: 'sportRank'

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1496,7 +1496,7 @@ def standings_data(
                 "elim_num": x.get("eliminationNumber", "-"),
                 "team_id": x["team"]["id"],
                 "league_rank": x["leagueRank"],
-                "sport_rank": x["sportRank"],
+                "sport_rank": x.get("sportRank", "-"),
             }
             divisions[x["team"]["division"]["id"]]["teams"].append(team)
 


### PR DESCRIPTION
Yet another fix to standings_data. Now one can get standings with standingsTypes='springTraining'