### PR TITLE
Issue 115 - Standings_data division parameter should accept divisionId instead of only abbreviation

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1448,9 +1448,7 @@ def standings_data(
     standingsTypes=None,
     date=None,
 ):
-    print("getting standings data")
-    print("division")
-    print(division)
+    
     """Returns a dict of standings data for a given league/division and season."""
     params = {"leagueId": leagueId}
     if date:
@@ -1473,13 +1471,12 @@ def standings_data(
         }
     )
 
-    print(params)
     r = get("standings", params)
 
     divisions = {}
 
     for y in r["records"]:
-        print(y["division"]["id"])
+
         for x in (
             x
             for x in y["teamRecords"]
@@ -1488,7 +1485,6 @@ def standings_data(
             or str(division) == str(x["team"]["division"]["id"])
             
         ):
-            print(x)
             if x["team"]["division"]["id"] not in divisions.keys():
                 divisions.update(
                     {

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1440,6 +1440,7 @@ def standings(
 
 
 def standings_data(
+    
     leagueId="103,104",
     division="all",
     include_wildcard=True,
@@ -1447,6 +1448,9 @@ def standings_data(
     standingsTypes=None,
     date=None,
 ):
+    print("getting standings data")
+    print("division")
+    print(division)
     """Returns a dict of standings data for a given league/division and season."""
     params = {"leagueId": leagueId}
     if date:
@@ -1469,17 +1473,22 @@ def standings_data(
         }
     )
 
+    print(params)
     r = get("standings", params)
 
     divisions = {}
 
     for y in r["records"]:
+        print(y["division"]["id"])
         for x in (
             x
             for x in y["teamRecords"]
             if division.lower() == "all"
             or division.lower() == x["team"]["division"]["abbreviation"].lower()
+            or str(division) == str(x["team"]["division"]["id"])
+            
         ):
+            print(x)
             if x["team"]["division"]["id"] not in divisions.keys():
                 divisions.update(
                     {


### PR DESCRIPTION
Added conditional to the standings_data that allows users to query for standings data by division id