### PR TITLE
proposal: v1.9

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1647,7 +1647,7 @@ def notes(endpoint):
     return msg
 
 
-def get(endpoint, params={}, force=False):
+def get(endpoint, params={}, force=False, *, request_kwargs={}):
     """Call MLB StatsAPI and return JSON data.
 
     This function is for advanced querying of the MLB StatsAPI,
@@ -1771,7 +1771,7 @@ def get(endpoint, params={}, force=False):
         )
 
     # Make the request
-    r = requests.get(url)
+    r = requests.get(url, **request_kwargs)
     if r.status_code not in [200, 201]:
         r.raise_for_status()
     else:

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1122,9 +1122,9 @@ def game_pace_data(season=datetime.now().year, sportId=1):
     return r
 
 
-def player_stats(personId, group="[hitting,pitching,fielding]", type="season"):
+def player_stats(personId, group="[hitting,pitching,fielding]", type="season", season=None):
     """Get current season or career stats for a given player."""
-    player = player_stat_data(personId, group, type)
+    player = player_stat_data(personId, group, type, season)
 
     stats = ""
     stats += player["first_name"]
@@ -1160,15 +1160,22 @@ def player_stats(personId, group="[hitting,pitching,fielding]", type="season"):
 
 
 def player_stat_data(
-    personId, group="[hitting,pitching,fielding]", type="season", sportId=1
+    personId, group="[hitting,pitching,fielding]", type="season", sportId=1, season=None
 ):
     """Returns a list of current season or career stat data for a given player."""
+
+    if season is not None and 'season' not in type:
+        raise ValueError(
+            "The 'season' parameter is only valid when using the 'season' type."
+        )
+
     params = {
         "personId": personId,
         "hydrate": "stats(group="
         + group
         + ",type="
         + type
+        + (",season=" + str(season) if season else "")
         + ",sportId="
         + str(sportId)
         + "),currentTeam",

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1122,7 +1122,9 @@ def game_pace_data(season=datetime.now().year, sportId=1):
     return r
 
 
-def player_stats(personId, group="[hitting,pitching,fielding]", type="season", season=None):
+def player_stats(
+    personId, group="[hitting,pitching,fielding]", type="season", season=None
+):
     """Get current season or career stats for a given player."""
     player = player_stat_data(personId, group, type, season)
 
@@ -1164,7 +1166,7 @@ def player_stat_data(
 ):
     """Returns a list of current season or career stat data for a given player."""
 
-    if season is not None and 'season' not in type:
+    if season is not None and "season" not in type:
         raise ValueError(
             "The 'season' parameter is only valid when using the 'season' type."
         )
@@ -1224,10 +1226,7 @@ def latest_season(sportId=1):
         (
             s
             for s in all_seasons.get("seasons", [])
-            if (
-                datetime.today().strftime("%Y-%m-%d")
-                < s.get("seasonEndDate", "")
-            )
+            if (datetime.today().strftime("%Y-%m-%d") < s.get("seasonEndDate", ""))
         ),
         all_seasons["seasons"][-1],
     )
@@ -1775,6 +1774,11 @@ def get(endpoint, params={}, force=False, *, request_kwargs={}):
             + str(ep.get("required_params", []))
             + ". \n--Note: If there are multiple sets in the required parameter list, you can choose any of the sets."
             + note
+        )
+
+    if len(request_kwargs):
+        logger.debug(
+            "Including request_kwargs in requests.get call: {}".format(request_kwargs)
         )
 
     # Make the request

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -49,6 +49,7 @@ def schedule(
     sportId=1,
     game_id=None,
     leagueId=None,
+    season=None,
 ):
     """Get list of games for a given date/range and/or team/opponent."""
     if end_date and not start_date:
@@ -77,6 +78,9 @@ def schedule(
 
     if leagueId:
         params.update({"leagueId": leagueId})
+
+    if season:
+        params.update({"season": season})
 
     hydrate = (
         "decisions,probablePitcher(note),linescore,broadcasts,game(content(media(epg)))"

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1578,6 +1578,7 @@ def meta(type, fields=None):
         "awards",
         "baseballStats",
         "eventTypes",
+        "freeGameTypes",
         "gameStatus",
         "gameTypes",
         "hitTrajectories",
@@ -1592,12 +1593,15 @@ def meta(type, fields=None):
         "positions",
         "reviewReasons",
         "rosterTypes",
+        "runnerDetailTypes",
+        "scheduleTypes",
         "scheduleEventTypes",
         "situationCodes",
         "sky",
         "standingsTypes",
         "statGroups",
         "statTypes",
+        "violationTypes",
         "windDirection",
     ]
     if type not in types:

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1213,14 +1213,11 @@ def latest_season(sportId=1):
     all_seasons = get("season", params)
     return next(
         (
-            x
-            for x in all_seasons.get("seasons", [])
-            if x.get("seasonStartDate")
-            and x.get("seasonEndDate")
-            and (
-                x["seasonStartDate"]
-                < datetime.today().strftime("%Y-%m-%d")
-                < x["seasonEndDate"]
+            s
+            for s in all_seasons.get("seasons", [])
+            if (
+                datetime.today().strftime("%Y-%m-%d")
+                < s.get("seasonEndDate", "")
             )
         ),
         all_seasons["seasons"][-1],

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -50,6 +50,7 @@ def schedule(
     game_id=None,
     leagueId=None,
     season=None,
+    include_series_status=True,
 ):
     """Get list of games for a given date/range and/or team/opponent."""
     if end_date and not start_date:
@@ -85,13 +86,14 @@ def schedule(
     hydrate = (
         "decisions,probablePitcher(note),linescore,broadcasts,game(content(media(epg)))"
     )
-    if date == "2014-03-11" or (str(start_date) <= "2014-03-11" <= str(end_date)):
-        # For some reason the seriesStatus hydration throws a server error on 2014-03-11 only (checked back to 2000)
-        logger.warning(
-            "Excluding seriesStatus hydration because the MLB API throws an error for 2014-03-11 which is included in the requested date range."
-        )
-    else:
-        hydrate += ",seriesStatus"
+    if include_series_status:
+        if date == "2014-03-11" or (str(start_date) <= "2014-03-11" <= str(end_date)):
+            # For some reason the seriesStatus hydration throws a server error on 2014-03-11 only (checked back to 2000)
+            logger.warning(
+                "Excluding seriesStatus hydration because the MLB API throws an error for 2014-03-11 which is included in the requested date range."
+            )
+        else:
+            hydrate += ",seriesStatus"
     params.update(
         {
             "sportId": str(sportId),

--- a/statsapi/endpoints.py
+++ b/statsapi/endpoints.py
@@ -404,6 +404,25 @@ ENDPOINTS = {
         "query_params": ["timecode", "fields"],
         "required_params": [[]],
     },
+    "game_uniforms": {
+        "url": BASE_URL + "{ver}/uniforms/game",
+        "path_params": {
+            "ver": {
+                "type": "str",
+                "default": "v1",
+                "leading_slash": False,
+                "trailing_slash": False,
+                "required": True,
+            }
+        },
+        "query_params": [
+            "gamePks",
+            "fields",
+        ],
+        "required_params": [
+            ["gamePks"],
+        ],
+    },
     "gamePace": {
         "url": BASE_URL + "{ver}/gamePace",
         "path_params": {
@@ -1284,6 +1303,26 @@ ENDPOINTS = {
         ],
         "required_params": [["season", "group"]],
         "note": "Use meta('statGroups') to look up valid values for group, meta('statTypes') for valid values for stats, and meta('situationCodes') for valid values for sitCodes. Use sitCodes with stats=statSplits.",
+    },
+    "team_uniforms": {
+        "url": BASE_URL + "{ver}/uniforms/team",
+        "path_params": {
+            "ver": {
+                "type": "str",
+                "default": "v1",
+                "leading_slash": False,
+                "trailing_slash": False,
+                "required": True,
+            }
+        },
+        "query_params": [
+            "teamIds",
+            "season",
+            "fields",
+        ],
+        "required_params": [
+            ["teamIds"],
+        ],
     },
     "transactions": {
         "url": BASE_URL + "{ver}/transactions",

--- a/statsapi/version.py
+++ b/statsapi/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = "1.8.1"
+VERSION = "1.9.0"


### PR DESCRIPTION
Features:

- New uniform endpoints `game_uniforms` and `team_uniforms` (#154)
- `schedule()` supports the `season` argument to get an entire season's games at once (#149)
- `player_stats()` and `player_stats_data()` support the `season` argument to get previous seasons of stats (#161)
- `get()` now accepts a `requests_kwargs` dict which are passed as extra arguments to `requests.get()` (#159)

Bug fixes:

- Fixed the offseason behavior of the `latest_season()` function to return the upcoming season, not just whatever the most recent in MLB's data is (#157)
- `schedule()` supports passing `include_series_status=False` to not request the series status from the endpoint, which can fail when requesting schedules covering large periods of time (#158)