### PR TITLE
Flatten all matching gamePk highlights across dates

### DIFF
--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1056,12 +1056,20 @@ def game_highlight_data(gamePk):
             "fields": "dates,date,games,gamePk,content,highlights,items,headline,type,value,title,description,duration,playbacks,name,url",
         },
     )
-    gameHighlights = (
-        r["dates"][0]["games"][0]
-        .get("content", {})
-        .get("highlights", {})
-        .get("highlights", {})
-    )
+
+    gameHighlights = { "items": [] }
+
+    for date in r["dates"]:
+        for game in date["games"]:
+            highlights = (
+                game.get("content", {})
+                .get("highlights", {})
+                .get("highlights", {})
+                .get("items", [])
+            )
+
+            gameHighlights["items"].extend(highlights)
+
     if not gameHighlights or not len(gameHighlights.get("items", [])):
         return []
 

--- a/statsapi/__init__.py
+++ b/statsapi/__init__.py
@@ -1057,7 +1057,7 @@ def game_highlight_data(gamePk):
         },
     )
 
-    gameHighlights = { "items": [] }
+    gameHighlights = []
 
     for date in r["dates"]:
         for game in date["games"]:
@@ -1068,24 +1068,9 @@ def game_highlight_data(gamePk):
                 .get("items", [])
             )
 
-            gameHighlights["items"].extend(highlights)
+            gameHighlights.extend(h for h in highlights if isinstance(h, dict) and h.get("type") == "video")
 
-    if not gameHighlights or not len(gameHighlights.get("items", [])):
-        return []
-
-    unorderedHighlights = {}
-    for v in (
-        x
-        for x in gameHighlights["items"]
-        if isinstance(x, dict) and x["type"] == "video"
-    ):
-        unorderedHighlights.update({v["date"]: v})
-
-    sortedHighlights = []
-    for x in sorted(unorderedHighlights):
-        sortedHighlights.append(unorderedHighlights[x])
-
-    return sortedHighlights
+    return sorted(gameHighlights, key=lambda x: x["date"])
 
 
 def game_pace(season=datetime.now().year, sportId=1):


### PR DESCRIPTION
Addresses #164

`gamePk` is the unique ID for a game even across multiple dates, such as the example where a rainout moves the game to a later date. This causes the first game to have empty highlights, but the second has actual data.

This change allows `game_highlight_data()` to grab every highlight across multiple dates and flatten them into a single list.